### PR TITLE
Fixes, Linux support, C++17 update, and RxCpp update

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -109,10 +109,21 @@ const SDL_Color white = { 255, 255, 255, 255 };
 * @return observable<int>
 */
 const auto application = [](SDL_Renderer *renderer, rx::observable<SDL_Event*> events, rx::observable<t::milliseconds> updates, rx::observable<SDL_Renderer *> renders) {
+    std::vector<std::filesystem::path>font_path_vector = 
+        {std::filesystem::path("/Library/Fonts/Arial.ttf"), 
+        std::filesystem::path("/usr/share/fonts/truetype/freefont/FreeSans.ttf")};
+    std::filesystem::path font_file;
+    for (auto file_path_iter : font_path_vector)
+    {
+        if (std::filesystem::exists(file_path_iter) == true)
+        {
+            font_file = file_path_iter;
+            break;
+        }
+    }
 
-    auto arrow = draw_text(renderer, "/Library/Fonts/Arial.ttf", 36, "Time flies like an arrow", white);
-
-    auto dreadpirate = draw_text(renderer, "/Library/Fonts/Arial.ttf", 26, "Get used to disappointment", white);
+    auto arrow = draw_text(renderer, font_file.c_str(), 36, "Time flies like an arrow", white);
+    auto dreadpirate = draw_text(renderer, font_file.c_str(), 26, "Get used to disappointment", white);
 
     return texture_circling_mouse(arrow, 1.0, 50, events, updates, renders).
         merge(texture_circling_mouse(dreadpirate, 2.0, 100, events, updates, renders));

--- a/precomp.h
+++ b/precomp.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <iostream>
+#include <filesystem>
 #include <SDL2/SDL.h>
-#include <SDL2_ttf/SDL_ttf.h>
+#include <SDL2/SDL_ttf.h>
 
 #include <assert.h>
 

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -7,9 +7,9 @@ MESSAGE( STATUS "CMAKE_CXX_COMPILER_ID: " ${CMAKE_CXX_COMPILER_ID} )
 FIND_PACKAGE(Threads)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    list( APPEND CMAKE_CXX_FLAGS " -std=c++1y -ftemplate-depth=1024 ${CMAKE_CXX_FLAGS}")
+    list( APPEND CMAKE_CXX_FLAGS " -std=c++17 -ftemplate-depth=1024 ${CMAKE_CXX_FLAGS}")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    list( APPEND CMAKE_CXX_FLAGS " -std=c++1y ${CMAKE_CXX_FLAGS}")
+    list( APPEND CMAKE_CXX_FLAGS " -std=c++17 ${CMAKE_CXX_FLAGS}")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     list( APPEND CMAKE_CXX_FLAGS " /DUNICODE /D_UNICODE /bigobj ${CMAKE_CXX_FLAGS}")
 endif()
@@ -48,7 +48,13 @@ set(SDLTEXT_SOURCES
 )
 
 add_executable(circle ${SDLTEXT_SOURCES})
-TARGET_LINK_LIBRARIES(circle ${CMAKE_THREAD_LIBS_INIT} ${SDL_LIBRARY} ${SDL_TTF_LIBRARY})
+
+# GCC versions 5.3 through 8.x need stdc++fs for std::filesystem
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    TARGET_LINK_LIBRARIES(circle ${CMAKE_THREAD_LIBS_INIT} ${SDL_LIBRARY} ${SDL_TTF_LIBRARY} stdc++fs)
+else()
+    TARGET_LINK_LIBRARIES(circle ${CMAKE_THREAD_LIBS_INIT} ${SDL_LIBRARY} ${SDL_TTF_LIBRARY})
+endif()
 
 # configure unit tests via CTest
 enable_testing()


### PR DESCRIPTION
C++17 support of `std::filesystem` is enabled by `-lstdc++fs` which more or less is a flag instead of a file. [Best known practice](https://stackoverflow.com/questions/44476810/build-project-with-experimental-filesystem-using-cmake) was used in the `CMakefile` to link to that library.